### PR TITLE
Fix dead Lending Club dataset link in Loan experiment

### DIFF
--- a/docs/experiments/Loan.ipynb
+++ b/docs/experiments/Loan.ipynb
@@ -88,7 +88,7 @@
     "\n",
     "References:\n",
     "\n",
-    "1. https://www.kaggle.com/wendykan/lending-club-loan-data (Note: Currently, the dataset seems to be withdrawn from kaggle)"
+    "1. https://www.kaggle.com/datasets/adarshsng/lending-club-loan-data-csv"
    ]
   },
   {

--- a/nbs/experiments/Loan.ipynb
+++ b/nbs/experiments/Loan.ipynb
@@ -81,7 +81,7 @@
     "\n",
     "References:\n",
     "\n",
-    "1. https://www.kaggle.com/wendykan/lending-club-loan-data (Note: Currently, the dataset seems to be withdrawn from kaggle)"
+    "1. https://www.kaggle.com/datasets/adarshsng/lending-club-loan-data-csv"
    ]
   },
   {

--- a/nbs/experiments/_Experiments.ipynb
+++ b/nbs/experiments/_Experiments.ipynb
@@ -7326,7 +7326,7 @@
     "\n",
     "References:\n",
     "\n",
-    "1. https://www.kaggle.com/wendykan/lending-club-loan-data (Note: Currently, the dataset seems to be withdrawn from kaggle)"
+    "1. https://www.kaggle.com/datasets/adarshsng/lending-club-loan-data-csv"
    ]
   },
   {


### PR DESCRIPTION
The archived **Loan** experiment linked `kaggle.com/wendykan/lending-club-loan-data`, which is **404** (the dataset was withdrawn by its owner — the notebook already noted this).

Replaced it with the live re-upload of the same 2007–2015 Lending Club data: [`kaggle.com/datasets/adarshsng/lending-club-loan-data-csv`](https://www.kaggle.com/datasets/adarshsng/lending-club-loan-data-csv) (verified **200**), and dropped the now-stale "withdrawn from kaggle" note. Updated the published copy (`docs/experiments/Loan.ipynb`) and the source notebooks (`nbs/experiments/Loan.ipynb`, `_Experiments.ipynb`).

This clears the last broken link found in the site crawl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)