### PR TITLE
ci: add PyPI Trusted-Publishing workflow + RELEASING runbook

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,73 @@
+name: Publish
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'Publish target'
+        required: true
+        default: 'testpypi'
+        type: choice
+        options:
+          - testpypi
+          - pypi
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    # Release events always go to real PyPI. Manual dispatch honors `target`.
+    # The environment name selects the matching Trusted-Publishing identity.
+    environment:
+      name: ${{ (github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi') && 'testpypi' || 'pypi' }}
+      url: ${{ (github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi') && 'https://test.pypi.org/p/monotonic-nn' || 'https://pypi.org/p/monotonic-nn' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Get version from pyproject.toml
+        id: version
+        run: |
+          VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          echo "package_version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Package version: $VERSION"
+
+      - name: Verify release tag matches version
+        if: github.event_name == 'release'
+        run: |
+          VERSION="${{ steps.version.outputs.package_version }}"
+          TAG="${{ github.event.release.tag_name }}"
+          TAG_VERSION="${TAG#v}"
+          echo "Release tag: $TAG (-> $TAG_VERSION); pyproject version: $VERSION"
+          if [ "$VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::Release tag $TAG (-> $TAG_VERSION) does not match pyproject version $VERSION" >&2
+            exit 1
+          fi
+
+      - name: Build package
+        run: |
+          python -m pip install --upgrade build
+          python -m build
+
+      - name: Verify build artifacts
+        run: |
+          ls -lh dist/
+          test -f "dist/monotonic_nn-${{ steps.version.outputs.package_version }}-py3-none-any.whl"
+          test -f "dist/monotonic_nn-${{ steps.version.outputs.package_version }}.tar.gz"
+
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # Empty repository-url defaults to real PyPI; set to TestPyPI only on
+          # a manual dispatch that selected the testpypi target.
+          repository-url: ${{ (github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi') && 'https://test.pypi.org/legacy/' || '' }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,66 @@
+# Releasing
+
+`monotonic-nn` is a deprecated compatibility shim over
+[mononet](https://github.com/davorrunje/mononet). Publishing uses **PyPI
+Trusted Publishing** (OIDC) via [`.github/workflows/publish.yml`](.github/workflows/publish.yml)
+— no API tokens or stored secrets.
+
+## One-time setup (maintainer, web UI)
+
+1. **GitHub environments.** Repo Settings → Environments → create `testpypi`
+   and `pypi`.
+2. **TestPyPI trusted publisher** — at
+   <https://test.pypi.org/manage/account/publishing/> add a publisher:
+   - Project name: `monotonic-nn`
+   - Owner: `airtai`, Repository: `monotonic-nn`
+   - Workflow name: `publish.yml`
+   - Environment name: `testpypi`
+3. **PyPI trusted publisher** — repeat at
+   <https://pypi.org/manage/account/publishing/> with environment name `pypi`.
+
+If a value is wrong, the upload fails at the OIDC exchange with a
+"not a trusted publisher" error.
+
+## Version
+
+The version lives in `pyproject.toml` (`project.version`) and
+`airt/__init__.py` (`__version__`), and is asserted in
+`tests/test_reexport.py`. Keep all three in sync.
+
+## TestPyPI rehearsal (recommended before every real release)
+
+1. Ensure `main` is green.
+2. Actions → **Publish** → Run workflow → `target: testpypi`.
+3. Verify the project page at <https://test.pypi.org/project/monotonic-nn/> and
+   a clean install. Dependencies (`mononet`, `tensorflow`) are not on TestPyPI,
+   so pull them from real PyPI:
+   ```sh
+   pip install --pre \
+     -i https://test.pypi.org/simple/ \
+     --extra-index-url https://pypi.org/simple/ \
+     monotonic-nn==<version>
+   ```
+
+## Real PyPI release
+
+1. Bump the version (`pyproject.toml`, `airt/__init__.py`,
+   `tests/test_reexport.py`) and update `CHANGELOG.md`; merge to `main`.
+2. Create a **GitHub Release**: tag `v<version>` (e.g. `v0.4.0`), target the
+   merge commit on `main`. Mark **pre-release** for alphas/betas/rcs.
+3. Publishing the release fires the **Publish** workflow to real PyPI. It fails
+   fast if the tag does not match the `pyproject.toml` version.
+
+## Planned final release: v0.4.0
+
+`0.4.0` is intended as the **final** release of this shim, cut once
+**mononet 0.0.1** is published to PyPI. Before tagging `v0.4.0`:
+
+- [ ] mononet `0.0.1` is live on PyPI.
+- [ ] Bump version `0.4.0a1` → `0.4.0` in `pyproject.toml`, `airt/__init__.py`,
+      and `tests/test_reexport.py` (assertion + test name).
+- [ ] Change the dependency in `pyproject.toml` from `mononet>=0.0.0a1` to
+      `mononet>=0.0.1` (drops the prerelease specifier so a stable install does
+      not pull mononet prereleases).
+- [ ] Update `CHANGELOG.md` (`## 0.4.0`) and the README banner
+      (`v0.4.0a1` → `v0.4.0`).
+- [ ] TestPyPI rehearsal, then the GitHub Release `v0.4.0`.


### PR DESCRIPTION
Adds trusted-publishing (OIDC, no tokens) so `monotonic-nn` can be released to
TestPyPI and PyPI — the repo currently has no publish path (the old nbdev
`airtai/workflows` release was removed in the v0.4.0a1 shim migration).

## `.github/workflows/publish.yml`
Mirrors the `mononet` publish workflow:
- `release: published` → **real PyPI**; `workflow_dispatch` with `target`
  (`testpypi`/`pypi`) for rehearsals.
- `environment` selects the matching trusted-publishing identity; builds with
  `python -m build`, reads the version from `pyproject.toml`, verifies the
  `monotonic_nn-<ver>` artifacts, checks the release tag `v<version>` matches,
  and publishes via `pypa/gh-action-pypi-publish`.

## `RELEASING.md`
One-time trusted-publisher setup (TestPyPI + PyPI, `testpypi`/`pypi` GitHub
environments), the TestPyPI rehearsal steps, and the **planned final v0.4.0**
checklist (gated on mononet 0.0.1: bump `0.4.0a1 → 0.4.0` and switch the
dependency to `mononet>=0.0.1`).

## After merge (maintainer, web UI — cannot be automated)
1. Create GitHub environments `testpypi` and `pypi`.
2. Add TestPyPI + PyPI trusted publishers for project `monotonic-nn`, repo
   `airtai/monotonic-nn`, workflow `publish.yml`, matching environment names.
3. Actions → **Publish** → `target: testpypi` to rehearse `0.4.0a1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)